### PR TITLE
fix hikashop order language

### DIFF
--- a/extension/plg_sys_webwinkelkeur/WebwinkelKeurHikaShopPlatform.php
+++ b/extension/plg_sys_webwinkelkeur/WebwinkelKeurHikaShopPlatform.php
@@ -96,7 +96,9 @@ class WebwinkelKeurHikaShopPlatform implements WebwinkelKeurShopPlatform {
         return $order['customer_name'];
     }
 
-    public function getOrderLanguage($order) {}
+    public function getOrderLanguage($order) {
+        return isset($this->getOrderData($order)['order']['order_lang']) ? $this->getOrderData($order)['order']['order_lang'] : 'cus';
+    }
 
     public function getOrderPhones($order) {
         $order_data = $this->getOrderData($order);

--- a/extension/plg_sys_webwinkelkeur/WebwinkelKeurHikaShopPlatform.php
+++ b/extension/plg_sys_webwinkelkeur/WebwinkelKeurHikaShopPlatform.php
@@ -97,7 +97,7 @@ class WebwinkelKeurHikaShopPlatform implements WebwinkelKeurShopPlatform {
     }
 
     public function getOrderLanguage($order) {
-        return isset($this->getOrderData($order)['order']['order_lang']) ? $this->getOrderData($order)['order']['order_lang'] : 'cus';
+        return isset($this->getOrderData($order)['order']['order_lang']) ? $this->getOrderData($order)['order']['order_lang'] : null;
     }
 
     public function getOrderPhones($order) {


### PR DESCRIPTION
https://app.clubhouse.io/webwinkelkeur/story/475/joomla-multi-language-review-requests
Hikashop members receive requests only in their default language.

The function which is used to retrieve the language does not return anything.
`public function getOrderLanguage($order) {}`
Order data holds two variables with the language 'order_lang' and 'site_lang'

[ch475]
